### PR TITLE
Turning on the unittest's test runner right from setup.py script. Also, added the travis-ci config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - 2.5
+  - 2.6
+  - 2.7
+script:  python setup.py test
+

--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,5 @@ setup(
         "Topic :: Software Development :: Testing",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    test_suite="test",
 )


### PR DESCRIPTION
**Travis-ci support must be turned on by the repository owner.**

Travis-ci lacks support to python 2.4, so for now the tests were configured from 2.5 to 2.7. 
